### PR TITLE
Userモデルに admin カラムを追加

### DIFF
--- a/db/migrate/20250520035020_add_admin_to_users.rb
+++ b/db/migrate/20250520035020_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :admin, :boolean
+  end
+end

--- a/db/migrate/20250520035020_add_admin_to_users.rb
+++ b/db/migrate/20250520035020_add_admin_to_users.rb
@@ -1,5 +1,5 @@
 class AddAdminToUsers < ActiveRecord::Migration[8.0]
   def change
-    add_column :users, :admin, :boolean
+    add_column :users, :admin, :boolean, default: false
   end
 end

--- a/db/migrate/20250520035020_add_admin_to_users.rb
+++ b/db/migrate/20250520035020_add_admin_to_users.rb
@@ -1,5 +1,5 @@
 class AddAdminToUsers < ActiveRecord::Migration[8.0]
   def change
-    add_column :users, :admin, :boolean, default: false
+    
   end
 end

--- a/db/migrate/20250521015834_change_admin_default_in_users.rb
+++ b/db/migrate/20250521015834_change_admin_default_in_users.rb
@@ -1,0 +1,5 @@
+class ChangeAdminDefaultInUsers < ActiveRecord::Migration[8.0]
+  def change
+    change_column :users, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_03_141651) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_21_015834) do
   create_table "cart_products", force: :cascade do |t|
     t.integer "cart_id", null: false
     t.integer "product_id", null: false
@@ -65,7 +65,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_03_141651) do
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
     t.string "name"
-    t.boolean "admin"
+    t.boolean "admin", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
## Issue
Related to 管理者が登録できる #20

### **Userモデルの `admin:boolean` によるロール分岐**
- adminカラム追加のためのマイグレーション作成
- `rails g migration AddAdminToUsers admin:boolean`