### PR TITLE
Adminコントローラー経由の新規登録時はFlagをtrueにする

### DIFF
--- a/app/controllers/admin/users/registrations_controller.rb
+++ b/app/controllers/admin/users/registrations_controller.rb
@@ -38,12 +38,17 @@ class Admin::Users::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
-  # protected
+  before_action :configure_sign_up_params, only: [:create]
 
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_up_params
-  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
-  # end
+  protected
+
+  def configure_sign_up_params
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:admin])
+  end
+
+  def build_resource(hash = {})
+    super(hash.merge(admin: true))
+  end
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_account_update_params


### PR DESCRIPTION
## Issue
<!-- 対応するIssue番号を記載（例：Closes #12） -->
https://github.com/yuki-snow1823/ec_demo/issues/44

## 概要
<!-- このPRで何を解決しようとしているか、背景や目的などを簡潔に記載 -->
新規登録時にAdmin::Users::RegistrationsController経由だった場合、adminのflagをtrueにします。

## やったこと
<!-- このPRで実装・修正した内容を列挙する -->
```
  User Load (0.1ms)  SELECT "users".* FROM "users" ORDER BY "users"."id" DESC LIMIT ?  [["LIMIT", 1]]
=> #<User id: 1, email: [FILTERED], name: nil, admin: true, created_at: "2025-05-22 22:15:22.026890000 +0000", updated_at: "2025-05-22 22:15:22.026890000 +0000">
```

## 変更確認方法
http://localhost:3000/admin/users/sign_up から登録してconsoleで確認。

## 参考
https://techracho.bpsinc.jp/hachi8833/2023_09_01/133452
https://deepwiki.com/heartcombo/devise で調査
