### PR TITLE
管理者用のProductコントローラを作成する

### DIFF
--- a/app/controllers/admin/product_controller.rb
+++ b/app/controllers/admin/product_controller.rb
@@ -1,0 +1,2 @@
+class Admin::ProductController < ApplicationController
+end

--- a/app/controllers/product_controller.rb
+++ b/app/controllers/product_controller.rb
@@ -1,0 +1,2 @@
+class ProductController < ApplicationController
+end

--- a/app/controllers/product_controller.rb
+++ b/app/controllers/product_controller.rb
@@ -1,2 +1,0 @@
-class ProductController < ApplicationController
-end

--- a/app/helpers/product_helper.rb
+++ b/app/helpers/product_helper.rb
@@ -1,0 +1,2 @@
+module ProductHelper
+end

--- a/spec/helpers/product_helper_spec.rb
+++ b/spec/helpers/product_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the ProductHelper. For example:
+#
+# describe ProductHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe ProductHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/product_spec.rb
+++ b/spec/requests/product_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Products", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
## Issue
#12 管理者は書籍の登録ができる 

## 概要
<!-- このPRで何を解決しようとしているか、背景や目的などを簡潔に記載 -->
admin用のProductコントローラを作成する。
管理者によって本の登録・編集・削除ができるよう準備する。

## やったこと
<!-- このPRで実装・修正した内容を列挙する -->
- productコントローラー作成

```bash
eliri@oguchierikanoMacBook-Air ec_demo % rails g controller product
config.eager_load is set to nil. Please update your config/environments/*.rb files accordingly:

  * development - set it to false
  * test - set it to false (unless you use a tool that preloads your test environment)
  * production - set it to true

      create  app/controllers/product_controller.rb
      invoke  erb
      create    app/views/product
      invoke  rspec
      create    spec/requests/product_spec.rb
      invoke  helper
      create    app/helpers/product_helper.rb
      invoke    rspec
      create      spec/helpers/product_helper_spec.rb
```

- Admin名前空間に変更
app/controllers/admin/product_controller.rb
```ruby
class Admin::ProductController < ApplicationController
end
```

- product_controller.rbを移動
`app/controllers/product_controller.rb`
↓
`app/controllers/admin/product_controller.rb`
