### PR TITLE
書籍登録時に必須箇所が入力されてないと、バリデーションメッセージを表示する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,8 @@ gem "thruster", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+gem 'rails-i18n'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem "thruster", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
-gem 'rails-i18n'
+gem "rails-i18n"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,6 +240,9 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (8.0.1)
+      i18n (>= 0.7, < 2)
+      railties (>= 8.0.0, < 9)
     railties (8.0.2)
       actionpack (= 8.0.2)
       activesupport (= 8.0.2)
@@ -387,6 +390,7 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rails (~> 8.0.2)
+  rails-i18n
   rspec-rails
   rubocop-rails-omakase
   solid_cache

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -21,3 +21,10 @@
   background-color: #dff0d8;
   border-color: #d6e9c6;
 }
+
+.error-message {
+  background:#FFEBE8;
+  border:2px solid #990000;
+  padding:12px; 
+  width: 500px;
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -25,6 +25,7 @@
 .error-message {
   background:#FFEBE8;
   border:2px solid #990000;
-  padding:12px; 
+  padding:1px; 
   width: 500px;
+  margin-bottom: 10px;
 }

--- a/app/controllers/admin/products_controller.rb
+++ b/app/controllers/admin/products_controller.rb
@@ -7,6 +7,7 @@ class Admin::ProductsController < ApplicationController
   end
 
   def new
+    @product = Product.new
   end
 
   def create

--- a/app/views/admin/products/new.html.erb
+++ b/app/views/admin/products/new.html.erb
@@ -1,30 +1,33 @@
 <h1>書籍新規投稿画面(管理者用)</h1>
-<%= form_with model: [:admin, Product.new] do |f| %>
-    <b>書籍名</b><br>
-    <%= f.text_field :name %>
-    <br>
 
-    <b>著者</b><br>
-    <%= f.text_field :author %>
-    <br>
+<%= form_with(model: @product, url: admin_products_path, scope: :product, data: { turbo: false }) do |f| %>
+  <%= render "layouts/error_messages", model: f.object %>
 
-    <b>価格</b><br>
-    <%= f.text_field :price %>
-    <br>
+  <b>書籍名</b><br>
+  <%= f.text_field :name %>
+  <br>
 
-    <b>在庫数</b><br>
-    <%= f.text_field :stock %>
-    <br>
+  <b>著者</b><br>
+  <%= f.text_field :author %>
+  <br>
 
-    <b>紹介文</b><br>
-    <%= f.text_area :description, rows: 4 %>
-    <br>
+  <b>価格</b><br>
+  <%= f.text_field :price %>
+  <br>
 
-    <b>公開設定</b><br>
-    <%= f.label :active do %>
-        <%= f.check_box :active %> 公開する
-    <% end %>
-    <br>
+  <b>在庫数</b><br>
+  <%= f.text_field :stock %>
+  <br>
 
-    <%= f.submit "登録" %>
+  <b>紹介文</b><br>
+  <%= f.text_area :description, rows: 4 %>
+  <br>
+
+  <b>公開設定</b><br>
+  <%= f.label :active do %>
+      <%= f.check_box :active %> 公開する
+  <% end %>
+  <br>
+
+  <%= f.submit "登録" %>
 <% end %>

--- a/app/views/layouts/_error_messages.html.erb
+++ b/app/views/layouts/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if model.errors.any? %>
+  <div class="error-message">
+    <ul>
+      <% model.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,5 +38,8 @@ module EcSite
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    # エラーメッセージの日本語設定のため追加
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,8 @@
+ja:
+  activerecord:
+    attributes:
+      product:
+        name: 書籍名
+        author: 著者
+        price: 価格
+        stock: 在庫数


### PR DESCRIPTION
## Issue
<!-- 対応するIssue番号を記載（例：Closes #12） -->
close #77 

## 概要
<!-- このPRで何を解決しようとしているか、背景や目的などを簡潔に記載 -->
現在はモデル・スキーマでバリデーションにより登録が弾かれて`render new` するが、
画面上には理由が表示されず、ユーザーが何を修正すべきか分からない状態のため、
バリデーションエラー時に適切なエラーメッセージを画面に表示する対応を行う。

以下でエラーを出す
- 必須項目（書籍名・著者名・価格・在庫数）が入力されてない
- 価格・在庫数が数字で入力されてない
- 価格・在庫数が0以上の数字である（マイナスは不可）
- 著者名が1文字以上100文字以内

## やったこと
<!-- このPRで実装・修正した内容を列挙する -->
- `_error_messages.html.erb`の作成
- `app/views/admin/products/new.html.erb`の修正
- エラーメッセージの日本語化（`rails-i18n`の導入、`ja.yml`の追加）

## 変更確認方法
<!-- ローカルでの確認方法、画面キャプチャ、手順などがあれば記載 -->
- http://localhost:3000/admin/products/new にアクセス
- 何も入力せず「登録」を押す。必須項目（書籍名・著者名・価格・在庫数）についてエラーが出るか確認
- 価格・在庫数を数字以外で入力してエラーが出るか
- 価格・在庫数をマイナスにしてエラーが出るか
- 著者名を100文字以上にしてエラーが出るか

![スクリーンショット 2025-06-10 103648](https://github.com/user-attachments/assets/bc026f5f-19a7-4f34-8546-1a238dd38f96)
![スクリーンショット 2025-06-10 104713](https://github.com/user-attachments/assets/16e572ea-8213-4a9e-acc8-d858f87d9016)
![スクリーンショット 2025-06-10 104759](https://github.com/user-attachments/assets/2233c102-6cd8-453f-9ebf-09409006fdc8)
![スクリーンショット 2025-06-10 104727](https://github.com/user-attachments/assets/4dcf2faf-3176-4a8e-b652-e327101c38fe)
