### PR TITLE
編集失敗時のバリデーションメッセージを追加

### DIFF
--- a/app/views/admin/products/edit.html.erb
+++ b/app/views/admin/products/edit.html.erb
@@ -3,7 +3,7 @@
 </div>
 
 <h1>編集画面(管理者用)</h1>
-<%= form_with(model: @product, url: admin_product_path(@product), scope: :product, data: { turbo: false }) do |f| %>
+<%= form_with(model: @product, url: admin_product_path(@product), data: { turbo: false }) do |f| %>
   <%= render "layouts/error_messages", model: f.object %>
 
   <b>書籍名</b><br>
@@ -22,7 +22,7 @@
   <%= f.text_field :stock %>
   <br>
 
-  <b>紹介文</b><br>
+  <b>説明</b><br>
   <%= f.text_area :description, rows: 4 %>
   <br>
 

--- a/app/views/admin/products/edit.html.erb
+++ b/app/views/admin/products/edit.html.erb
@@ -3,7 +3,9 @@
 </div>
 
 <h1>編集画面(管理者用)</h1>
-<%= form_with model: @product, url: admin_product_path(@product), method: :patch do |f| %>
+<%= form_with(model: @product, url: admin_product_path(@product), scope: :product, data: { turbo: false }) do |f| %>
+  <%= render "layouts/error_messages", model: f.object %>
+
   <b>書籍名</b><br>
   <%= f.text_field :name %>
   <br>

--- a/app/views/admin/products/new.html.erb
+++ b/app/views/admin/products/new.html.erb
@@ -1,6 +1,6 @@
 <h1>書籍新規投稿画面(管理者用)</h1>
 
-<%= form_with(model: @product, url: admin_products_path, scope: :product, data: { turbo: false }) do |f| %>
+<%= form_with(model: @product, url: admin_products_path, data: { turbo: false }) do |f| %>
   <%= render "layouts/error_messages", model: f.object %>
 
   <b>書籍名</b><br>
@@ -19,7 +19,7 @@
   <%= f.text_field :stock %>
   <br>
 
-  <b>紹介文</b><br>
+  <b>説明</b><br>
   <%= f.text_area :description, rows: 4 %>
   <br>
 

--- a/app/views/admin/products/show.html.erb
+++ b/app/views/admin/products/show.html.erb
@@ -27,7 +27,7 @@
 </p>
 
 <p>
-<b>紹介文</b><br>
+<b>説明</b><br>
 <%= @product.description %>
 </p>
 


### PR DESCRIPTION
## Issue
<!-- 対応するIssue番号を記載（例：Closes #12） -->
close #78 

## 概要
<!-- このPRで何を解決しようとしているか、背景や目的などを簡潔に記載 -->
登録のバリデーションと同様に対応する。

現在はモデル・スキーマでバリデーションにより登録が弾かれて`render edit` するが、
画面上には理由が表示されず、ユーザーが何を修正すべきか分からない状態のため、
バリデーションエラー時に適切なエラーメッセージを画面に表示する対応を行う。

## やったこと
<!-- このPRで実装・修正した内容を列挙する -->
- `app/views/admin/products/edit.html.erb`の修正


## 変更確認方法
<!-- ローカルでの確認方法、画面キャプチャ、手順などがあれば記載 -->
- http://localhost:3000/admin/products にアクセス
- 書籍名をクリックして詳細画面へ⇒「編集」をクリック
- 何も入力せず「登録」を押す。必須項目（書籍名・著者名・価格・在庫数）についてエラーが出るか確認
- 価格・在庫数を数字以外で入力してエラーが出るか
- 価格・在庫数をマイナスにしてエラーが出るか
- 著者名を100文字以上にしてエラーが出るか
![スクリーンショット 2025-06-10 155435](https://github.com/user-attachments/assets/ab47a1cd-5653-4489-85c4-adbf7fe0f417)
![スクリーンショット 2025-06-10 155012](https://github.com/user-attachments/assets/e9e57338-904e-4258-ae69-7d64f397947f)
![スクリーンショット 2025-06-10 155402](https://github.com/user-attachments/assets/d0b9aa4d-15b4-4d26-985c-88393af928a0)
