### PR TITLE
admin・user共通のproductsヘルパーにstock_labelメソッドを追加

### DIFF
--- a/app/controllers/admin/products_controller.rb
+++ b/app/controllers/admin/products_controller.rb
@@ -2,6 +2,9 @@ class Admin::ProductsController < ApplicationController
   before_action :authenticate_user!
   before_action :authorize_access_only_admin
 
+  # 共通の在庫表示ヘルパーを明示的に読み込み
+  helper ProductsHelper
+
   def index
     @products = Product.all
   end

--- a/app/controllers/users/products_controller.rb
+++ b/app/controllers/users/products_controller.rb
@@ -1,4 +1,7 @@
 class Users::ProductsController < ApplicationController
+  # 共通の在庫表示ヘルパーを明示的に読み込み
+  helper ProductsHelper
+
   def index
     @products = Product.where(active: true)
   end

--- a/app/helpers/admin/products_helper.rb
+++ b/app/helpers/admin/products_helper.rb
@@ -1,9 +1,4 @@
 module Admin::ProductsHelper
-  # def stock_label(product)
-  #   return "在庫切れ" if product.stock.to_i <= 0
-  #   "#{product.stock} 個"
-  # end
-
   def publication_status(product)
     product.active ? "公開" : "非公開"
   end

--- a/app/helpers/admin/products_helper.rb
+++ b/app/helpers/admin/products_helper.rb
@@ -1,8 +1,8 @@
 module Admin::ProductsHelper
-  def stock_label(product)
-    return "在庫切れ" if product.stock.to_i <= 0
-    "#{product.stock} 個"
-  end
+  # def stock_label(product)
+  #   return "在庫切れ" if product.stock.to_i <= 0
+  #   "#{product.stock} 個"
+  # end
 
   def publication_status(product)
     product.active ? "公開" : "非公開"

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -1,2 +1,6 @@
 module ProductsHelper
+  def stock_label(product)
+    return "在庫切れ" if product.stock.to_i <= 0
+    "#{product.stock} 個"
+  end
 end


### PR DESCRIPTION
## Issue
<!-- 対応するIssue番号を記載（例：Closes #12） -->
close #100 

## 概要
<!-- このPRで何を解決しようとしているか、背景や目的などを簡潔に記載 -->
userの一覧画面で、admin内の`products_helper`内にある`publication_status`を使用していた。
userでもadminでも使用するメソッドなので、共通の`products_helper`を作成し、そこに移動させる。

## やったこと
<!-- このPRで実装・修正した内容を列挙する -->
- `app/helpers/products_helper.rb`に`publication_status`メソッドを移動させる
- `app/helpers/admin/products_helper.rb`の修正

## 変更確認方法
<!-- ローカルでの確認方法、画面キャプチャ、手順などがあれば記載 -->
- 管理者：` http://127.0.0.1:3000/admin/products`にログイン⇒在庫0のものが在庫切れになってるか確認
- ユーザー：` http://127.0.0.1:3000/users/products`にログイン⇒在庫0のものが在庫切れになってるか確認
![image](https://github.com/user-attachments/assets/30fbb54e-6919-4476-a420-67c2e6275b76)
![image](https://github.com/user-attachments/assets/e70bcc8d-b77e-4345-8c22-ff2d815f6bbf)